### PR TITLE
feat(ui): implement root layout for TanStack Router

### DIFF
--- a/.jules/TASKS.md
+++ b/.jules/TASKS.md
@@ -79,7 +79,7 @@
 | FE-SETUP-008 | Pendente | FE-SETUP-001.6 | P1 | Frontend | [TSK-FE-SETUP-008.md](./tasks/TSK-FE-SETUP-008.md) |
 | ARCH-FE-UI-STRUCT-001 | Concluído | FE-SETUP-001.6 | P0 | Jules (Arquiteto) | [TSK-ARCH-FE-UI-STRUCT-001.md](./tasks/TSK-ARCH-FE-UI-STRUCT-001.md) |
 | FE-SETUP-010 | Concluído | FE-SETUP-001.1 | P0 | Jules | [TSK-FE-SETUP-010.md](./tasks/TSK-FE-SETUP-010.md) |
-| FE-LAYOUT-001| Pendente | FE-SETUP-002, FE-SETUP-003, ARCH-FE-UI-STRUCT-001 | P0 | Frontend | [TSK-FE-LAYOUT-001.md](./tasks/TSK-FE-LAYOUT-001.md) |
+| FE-LAYOUT-001| Em Andamento | FE-SETUP-002, FE-SETUP-003, ARCH-FE-UI-STRUCT-001 | P0 | Jules | [TSK-FE-LAYOUT-001.md](./tasks/TSK-FE-LAYOUT-001.md) |
 | FE-LAYOUT-002| Pendente | FE-LAYOUT-001, FE-COMP-SIDEBAR-APP | P1 | Frontend | [TSK-FE-LAYOUT-002.md](./tasks/TSK-FE-LAYOUT-002.md) |
 | FE-LAYOUT-003| Pendente | FE-LAYOUT-002, FE-COMP-SIDEBAR-PROJ | P1 | Frontend | [TSK-FE-LAYOUT-003.md](./tasks/TSK-FE-LAYOUT-003.md) |
 | FE-LAYOUT-004| Pendente | FE-LAYOUT-002, FE-COMP-SIDEBAR-USER | P1 | Frontend | [TSK-FE-LAYOUT-004.md](./tasks/TSK-FE-LAYOUT-004.md) |

--- a/.jules/tasks/TSK-FE-LAYOUT-001.md
+++ b/.jules/tasks/TSK-FE-LAYOUT-001.md
@@ -7,32 +7,35 @@ Implementar o layout raiz para o TanStack Router (ex: `__root.tsx`). Este compon
 
 ---
 
-**Status:** `Pendente`
+**Status:** `Em Andamento`
 **Dependências (IDs):** `FE-SETUP-002` (Shadcn/UI para possíveis componentes de layout base), `FE-SETUP-003` (TanStack Router configurado), `ARCH-FE-UI-STRUCT-001` (estrutura de pastas definida)
 **Complexidade (1-5):** `2`
 **Prioridade (P0-P4):** `P0` (Estrutura fundamental da UI)
-**Responsável:** `Frontend` (Originalmente, mas Jules pode iniciar)
+**Responsável:** `Jules`
 **Branch Git Proposta:** `feat/fe-layout-root`
 **Commit da Conclusão (Link):**
 
 ---
 
 ## Critérios de Aceitação
-- Arquivo de layout raiz (ex: `src_refactored/presentation/ui/routes/__root.tsx`) criado.
-- O layout raiz inclui o componente `<Outlet />` do TanStack Router para renderizar rotas filhas.
-- Provedores globais essenciais (ex: `ThemeProvider` do Shadcn/UI, `QueryClientProvider` do TanStack Query) são configurados neste layout ou no `main.tsx` se mais apropriado (decidir e documentar).
-- (Opcional) Pode incluir elementos de layout persistentes muito básicos, se houver (embora mais comum em layouts aninhados).
+- Arquivo de layout raiz (ex: `src_refactored/presentation/ui/routes/__root.tsx`) criado. **(Concluído)**
+- O layout raiz inclui o componente `<Outlet />` do TanStack Router para renderizar rotas filhas. **(Concluído)**
+- Provedores globais essenciais (ex: `ThemeProvider` do Shadcn/UI, `QueryClientProvider` do TanStack Query) são configurados neste layout. **(Concluído)**
+- (Opcional) Pode incluir elementos de layout persistentes muito básicos, se houver (embora mais comum em layouts aninhados). (Não incluído nesta etapa)
 
 ---
 
 ## Notas/Decisões de Design
 - Define a estrutura visual global com `<Outlet/>`.
-- Providers globais (Theme, QueryClient, etc.) são configurados em `presentation/ui/main.tsx` ou aqui. A nota original indica `main.tsx` para providers, o que é uma prática comum. O `__root.tsx` focaria mais na estrutura visual e no `<Outlet />`.
+- Providers globais (`ThemeProvider`, `QueryClientProvider`) foram configurados diretamente no `__root.tsx` para encapsular todas as rotas.
+- Um novo componente `ThemeProvider` foi criado em `src_refactored/presentation/ui/components/common/theme-provider.tsx` para gerenciar temas light/dark/system e interagir com `localStorage` e classes CSS no `<html>` element.
+- O `main.tsx` não necessitou de alterações, pois o `routeTree.gen.ts` (gerado pelo TanStack Router) é esperado para incorporar o `__root.tsx` automaticamente.
 
 ---
 
 ## Comentários
 - `(Data da migração): Tarefa migrada para novo formato.`
+- `(Data Atual): Iniciada a implementação. Criado __root.tsx com ThemeProvider e QueryClientProvider. ThemeProvider básico implementado.`
 
 ---
 

--- a/src_refactored/presentation/ui/components/common/theme-provider.tsx
+++ b/src_refactored/presentation/ui/components/common/theme-provider.tsx
@@ -1,0 +1,74 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+type Theme = 'light' | 'dark' | 'system'; // Added 'system' as a valid theme type
+
+interface ThemeProviderState {
+  theme: Theme; // This will store 'light' or 'dark' after resolving 'system'
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeProviderContext = createContext<ThemeProviderState | undefined>(undefined);
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+  defaultTheme?: Theme;
+  storageKey?: string;
+}
+
+export function ThemeProvider({
+  children,
+  defaultTheme = 'system',
+  storageKey = 'vite-ui-theme',
+}: ThemeProviderProps) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    try {
+      const storedTheme = localStorage.getItem(storageKey) as Theme | null;
+      if (storedTheme) {
+        return storedTheme;
+      }
+      return defaultTheme;
+    } catch (e) {
+      // localStorage is not available (e.g., SSR or restricted environment)
+      // console.warn('localStorage not available for theme persistence:', e);
+      return defaultTheme;
+    }
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove('light', 'dark');
+
+    let effectiveTheme = theme;
+    if (theme === 'system') {
+      effectiveTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    root.classList.add(effectiveTheme);
+
+    try {
+      // Store the raw theme value (could be 'system')
+      localStorage.setItem(storageKey, theme);
+    } catch (e) {
+      // Ignore localStorage errors if persistence fails
+      // console.warn('Failed to persist theme to localStorage:', e);
+    }
+  }, [theme, storageKey]);
+
+  const handleSetTheme = (newTheme: Theme) => {
+    setThemeState(newTheme);
+  };
+
+  return (
+    <ThemeProviderContext.Provider value={{ theme, setTheme: handleSetTheme }}>
+      {children}
+    </ThemeProviderContext.Provider>
+  );
+}
+
+export const useTheme = (): ThemeProviderState => {
+  const context = useContext(ThemeProviderContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/src_refactored/presentation/ui/routes/__root.tsx
+++ b/src_refactored/presentation/ui/routes/__root.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Outlet } from '@tanstack/react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '@/presentation/ui/components/common/theme-provider';
+
+const queryClient = new QueryClient();
+
+function RootApplicationLayout() {
+  return (
+    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+      <QueryClientProvider client={queryClient}>
+        <div className="min-h-screen bg-background text-foreground">
+          <Outlet />
+        </div>
+      </QueryClientProvider>
+    </ThemeProvider>
+  );
+}
+
+export default RootApplicationLayout;


### PR DESCRIPTION
- Created `src_refactored/presentation/ui/routes/__root.tsx` as the root layout.
- Integrated `ThemeProvider` and `QueryClientProvider` into the root layout.
- Added a basic `ThemeProvider` component in `src_refactored/presentation/ui/components/common/theme-provider.tsx` to handle light/dark/system themes.
- Ensured `tailwind.config.ts` is correctly set up for class-based dark mode.
- Updated task documentation for TSK-FE-LAYOUT-001.